### PR TITLE
Added "http/https" endpoint feature (to be used with a reverse proxy)

### DIFF
--- a/Proxy.py
+++ b/Proxy.py
@@ -797,6 +797,8 @@ class Config:
         self.hostname = None
         self.http_port = 0
         self.https_port = 0
+        self.http_endpoint = ''
+        self.https_endpoint = ''
         self.rewrites=[]
         self.http_listen_port = 0
         self.https_listen_port = 0
@@ -865,7 +867,9 @@ class Config:
             self.https_listen_port = conf.getint('global', 'https_listen_port')
             self.http_port = conf.getint('global', 'http_port')
             self.https_port = conf.getint('global', 'https_port')
-            self.https_certificate = conf.get('global','https_certificate')
+            self.http_endpoint = conf.get('global', 'http_endpoint')
+            self.https_endpoint = conf.get('global', 'https_endpoint')
+            self.https_certificate = conf.get('global', 'https_certificate')
             self.max_page_size = conf.getint('global', 'max_page_size')
             self.max_post_size = conf.getint('global', 'max_post_size')
             self.upstream_timeout=conf.getint('global', 'upstream_timeout')

--- a/Util.py
+++ b/Util.py
@@ -94,12 +94,14 @@ def rewrite_URL(url, config, ssl, remote_host):
         # Add port of proxy.
         if newres[0] == 'http':
             port = config.http_port
+            endpoint = config.http_endpoint
         elif newres[0] == 'https':
             port = config.https_port
+            endpoint = config.https_endpoint
         newres[1] = config.hostname + ":" + str(port)
         if host == '':
             host = remote_host
-        newres[2] = host + newres[2]
+        newres[2] = endpoint + host + newres[2]
         url = urlparse.urlunsplit(newres) 
     except Exception, e: 
         pass

--- a/proxy.conf
+++ b/proxy.conf
@@ -18,6 +18,10 @@ https_listen_port=40443
 http_port=80
 https_port=443
 
+;; The endpoints to rewrite URLs to for HTTP and HTTPs (to be used with a reverse proxy)
+;;http_endpoint=/http://
+;;https_endpoint=/https://
+
 ;; The certificate to use for HTTPS connections. This should be
 ;; readable by the user with which you run SwiperProxy.
 https_certificate=proxy.example.org.pem


### PR DESCRIPTION
Added "http/https" endpoint feature (to be used with a reverse proxy - eg.https://proxy.example.com/http://www.example.com/)