### PR TITLE
Changed JSPage rewrites behavior (from the old-style DNS to the new "standard")

### DIFF
--- a/JSPage.py
+++ b/JSPage.py
@@ -92,8 +92,10 @@ class JSPage(object):
 
         if self.ssl:
             port = self.config.https_port
+            endpoint = self.config.https_endpoint
         else:
             port = self.config.http_port
+            endpoint = self.config.http_endpoint
 
         # Not necessary to use standard port numbers. Assume proxy is
         # not doing HTTP on 443 or HTTPS on 80.
@@ -103,11 +105,10 @@ class JSPage(object):
             portstr = ':' + str(port)
 
         if scheme:
-            s = "".join((scheme, hostname, ".", self.config.hostname,
-                         portstr, s[m.end():]))
+            s = "".join((scheme, self.config.hostname, portstr, '/', endpoint, hostname, s[m.end():]))
         else:
-            s = "".join((scheme, hostname, ".", self.config.hostname,
-                         m.group(4) or '', s[m.end():]))
+            scheme = "http://"
+            s = "".join((scheme, self.config.hostname, portstr, '/', endpoint, hostname, m.group(4) or '', s[m.end():]))
 
         return s
 

--- a/JSPage.py
+++ b/JSPage.py
@@ -105,10 +105,10 @@ class JSPage(object):
             portstr = ':' + str(port)
 
         if scheme:
-            s = "".join((scheme, self.config.hostname, portstr, '/', endpoint, hostname, s[m.end():]))
+            s = "".join((scheme, self.config.hostname, portstr, endpoint, hostname, s[m.end():]))
         else:
             scheme = "http://"
-            s = "".join((scheme, self.config.hostname, portstr, '/', endpoint, hostname, m.group(4) or '', s[m.end():]))
+            s = "".join((scheme, self.config.hostname, portstr, endpoint, hostname, m.group(4) or '', s[m.end():]))
 
         return s
 

--- a/Proxy.py
+++ b/Proxy.py
@@ -797,8 +797,8 @@ class Config:
         self.hostname = None
         self.http_port = 0
         self.https_port = 0
-        self.http_endpoint = ''
-        self.https_endpoint = ''
+        self.http_endpoint = '/'
+        self.https_endpoint = '/'
         self.rewrites=[]
         self.http_listen_port = 0
         self.https_listen_port = 0


### PR DESCRIPTION
Changed JSPage rewrites behavior from the old-style DNS rewrite for the new "standard" (e.g. http://www.example.org.proxy.example.org -> http://proxy.example.org/www.example.org). This solves some NET::ERR_CERT_COMMON_NAME_INVALID problems.

This pull request also includes endpoint support for JSPage rewrite and the correction of the default endpoint to '/'.