### PR TITLE
Reverse Proxy URL rewrite support

### DIFF
--- a/JSPage.py
+++ b/JSPage.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 import re
+import Util
 
 BLKSIZE=65536
 
@@ -97,8 +98,16 @@ class JSPage(object):
             port = self.config.http_port
             endpoint = self.config.http_endpoint
 
+        if Util.using_reverseproxy(self.config):
+            if scheme != (self.config.reverseproxy_scheme + '://'):
+                scheme = (self.config.reverseproxy_scheme + '://')
+                if scheme == 'https://':
+                    port = self.config.https_port
+                else:
+                   port = self.config.http_port
+
         # Not necessary to use standard port numbers. Assume proxy is
-        # not doing HTTP on 443 or HTTPS on 80.
+        # not doing HTTPS on 443 or HTTP on 80.
         if port == 80 or port == 443:
             portstr = ''
         else:

--- a/Proxy.py
+++ b/Proxy.py
@@ -823,6 +823,7 @@ class Config:
         self.blocked_sites = self.parse_block_list(self.block_list)
         self.access_log = None
         self.error_log = None
+        self.reverseproxy_scheme = 'http'
 
         (opts, rest) = getopt.getopt(sys.argv[1:], "c:")
 
@@ -895,6 +896,7 @@ class Config:
             self.blocked_sites = self.parse_block_list(self.block_list)
             self.access_log = conf.get('global', 'access_log')
             self.error_log = conf.get('global', 'error_log')
+            self.reverseproxy_scheme = conf.get('global', 'reverseproxy_scheme')
 
         except Exception, e:
             print "Error while parsing configuration file:", e

--- a/proxy.conf
+++ b/proxy.conf
@@ -22,6 +22,9 @@ https_port=443
 ;;http_endpoint=/http://
 ;;https_endpoint=/https://
 
+;; Default reverse proxy scheme
+;;reverseproxy_scheme=https
+
 ;; The certificate to use for HTTPS connections. This should be
 ;; readable by the user with which you run SwiperProxy.
 https_certificate=proxy.example.org.pem


### PR DESCRIPTION
 - Added reverse proxy identification (by testing if config.http_endpoint == config.https_endpoint (Util.using_reverseproxy(config)))
 - Added configuration option reverseproxy_scheme (default is http). This option only used when Util.using_reverseproxy is True
 - Changed Util.rewrite and JSPage.rewrite_part to consider the reverse proxy scheme (and change the URLs accordingly)