### PR TITLE
remove endpoint in path for httplib.HTTPSConnection and referer headers

### DIFF
--- a/Proxy.py
+++ b/Proxy.py
@@ -149,6 +149,7 @@ class ProxyHandler(BaseHTTPRequestHandler):
             self.client_address = (client, self.client_address[1])
         if self.handle_own() or self.handle_robot_block():
             return
+        self.path = Util.remove_PATH_endpoint(self.path, self.server.config)
         self.remote_host = self.path.split('/')[1]
         self.path = '/' + '/'.join(self.path.split('/')[2:])
         self.server.reqs[threading.currentThread().name] = (self.remote_host,

--- a/Util.py
+++ b/Util.py
@@ -25,6 +25,17 @@
 import urlparse
 import traceback
 
+def remove_PATH_endpoint(path, config):
+    if path.startswith(config.https_endpoint):
+        lens = len(config.https_endpoint)
+        if lens:
+            path = path[lens-1:]
+    if path.startswith(config.http_endpoint):
+        lens = len(config.http_endpoint)
+        if lens:
+            path = path[lens-1:]
+    return path
+
 def rewrite_URL_strip(url, config):
     """
     Strip the proxy hostname part of the passed URL.
@@ -38,6 +49,8 @@ def rewrite_URL_strip(url, config):
            if host.endswith(config.hostname):
                host = host.split(config.hostname)[0]
            newres[1] = host
+
+           newres[2] = remove_PATH_endpoint(res[2], config)
 
            url = urlparse.urlunsplit(newres)
     except Exception, e:


### PR DESCRIPTION
https://github.com/swiperproxy/swiperproxy/blob/develop/Proxy.py#L152-L153

https://github.com/swiperproxy/swiperproxy/blob/develop/Util.py#L28-L45

for example, my configure is as following

```
http_endpoint=/
https_endpoint=/https/
```

After this patch, it will works.